### PR TITLE
Fixed spelling mistake of "simpleAudio"

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,7 +1,7 @@
 require("base_engine");
 require("simpleShaderLoading").init();
 require("textureSimplifier").init();
-require("SimpleAudio").init();
+require("simpleAudio").init();
 require("milos_grid_implementation").init();
 
 local theVenusProject = {};


### PR DESCRIPTION
in the require function, "SimpleAudio" was written instead of "simpleAudio", which crashed the .love.